### PR TITLE
Remove SoftDeletingTrait from User model

### DIFF
--- a/app/models/User.php
+++ b/app/models/User.php
@@ -4,5 +4,5 @@ use Orchestra\Model\User as Eloquent;
 
 class User extends Eloquent
 {
-	use SoftDeletingTrait;
+
 }


### PR DESCRIPTION
Since Orchestra/Model/User has already import the SoftDeletingTrait trait, importing it again in User model will throw an exception.

![orchestra](https://cloud.githubusercontent.com/assets/4233863/3363150/f5997cbc-fb10-11e3-85bf-a591482701c7.jpg)

Signed-off-by: Ahmad Shah Hafizan Hamidin ahmadshahhafizan@gmail.com
