### PR TITLE
Add Throttle Middleware as per Laravel 5.2.

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -44,6 +44,7 @@ class Kernel extends HttpKernel
     protected $routeMiddleware = [
         'auth' => Middleware\Authenticate::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
+        'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'backend' => \Orchestra\Foundation\Http\Middleware\UseBackendTheme::class,
         'can' => \Orchestra\Foundation\Http\Middleware\Can::class,
         'guest' => Middleware\RedirectIfAuthenticated::class,


### PR DESCRIPTION
The `api` middleware group requires this class and its present in Laravel 5.2.

It was throwing error while i was working on API part and noticed it was missing.